### PR TITLE
Fixed problem in which every save resets Query Info behaviour

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/QueryElasticsearchHttp.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-processors/src/main/java/org/apache/nifi/processors/elasticsearch/QueryElasticsearchHttp.java
@@ -259,7 +259,7 @@ public class QueryElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
                 this.relationships = routeQueryInfoRels;
 
                 this.queryInfoRouteStrategy = QueryInfoRouteStrategy.ALWAYS;
-            }else if (NO_HITS.getValue().equalsIgnoreCase(newValue)) {
+            } else if (NO_HITS.getValue().equalsIgnoreCase(newValue)) {
                 final Set<Relationship> routeQueryInfoRels = new HashSet<>();
                 routeQueryInfoRels.add(REL_SUCCESS);
                 routeQueryInfoRels.add(REL_FAILURE);
@@ -268,8 +268,7 @@ public class QueryElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
                 this.relationships = routeQueryInfoRels;
 
                 this.queryInfoRouteStrategy = QueryInfoRouteStrategy.NOHIT;
-            }
-            }else {
+            } else {
                 final Set<Relationship> successRels = new HashSet<>();
                 successRels.add(REL_SUCCESS);
                 successRels.add(REL_FAILURE);
@@ -279,6 +278,7 @@ public class QueryElasticsearchHttp extends AbstractElasticsearchHttpProcessor {
                 this.queryInfoRouteStrategy = QueryInfoRouteStrategy.NEVER;
             }
         }
+    }
 
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session)


### PR DESCRIPTION
@ottobackwards, I'm currently using e7025c53e5fd2b26ad7e708f57ea172fd0658bad and can confirm that the added functionality works mostly as expected, thank you for that. There appears to be one bug though: when making changes to the connector, the 'routing query info strategy' setting is always reset to 'NEVER'. A misplaced bracket seems to be the cause, which this pull request should fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ottobackwards/nifi/1)
<!-- Reviewable:end -->
